### PR TITLE
Added read resource test

### DIFF
--- a/core/src/main/kotlin/com/cognifide/apmt/tests/resource/ReadResourceTest.kt
+++ b/core/src/main/kotlin/com/cognifide/apmt/tests/resource/ReadResourceTest.kt
@@ -1,0 +1,44 @@
+package com.cognifide.apmt.tests.resource
+
+import com.cognifide.apmt.TestCase
+import com.cognifide.apmt.User
+import com.cognifide.apmt.actions.resource.ReadResource
+import com.cognifide.apmt.config.ConfigurationProvider
+import com.cognifide.apmt.config.Instance
+import com.cognifide.apmt.tests.Allowed
+import com.cognifide.apmt.tests.ApmtBaseTest
+import com.cognifide.apmt.tests.Denied
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Check user permissions to read resources")
+abstract class ReadResourceTest(
+    vararg testCases: TestCase,
+    private val instance: Instance = ConfigurationProvider.authorInstance,
+    private val deniedStatusCode: Int = 403
+) : ApmtBaseTest(*testCases) {
+
+    @DisplayName("User can read resources")
+    @ParameterizedTest
+    @Allowed
+    fun userCanReadResource(user: User, path: String) {
+        ReadResource(instance, user, path)
+            .execute()
+            .then()
+            .assertThat()
+            .statusCode(200)
+    }
+
+    @DisplayName("User cannot read resources")
+    @ParameterizedTest
+    @Denied
+    fun userCannotReadResource(user: User, path: String) {
+        ReadResource(instance, user, path)
+            .execute()
+            .then()
+            .assertThat()
+            .statusCode(deniedStatusCode)
+    }
+}

--- a/core/src/test/kotlin/com/cognifide/apmt/tests/resource/ApmtReadResourceTest.kt
+++ b/core/src/test/kotlin/com/cognifide/apmt/tests/resource/ApmtReadResourceTest.kt
@@ -1,0 +1,74 @@
+package com.cognifide.apmt.tests.resource
+
+import com.cognifide.apmt.actions.CSRF_TOKEN
+import com.cognifide.apmt.tests.ApmtUsers
+import com.cognifide.apmt.tests.testCase
+import com.cognifide.apmt.util.AemStub
+import com.cognifide.apmt.util.AemStubExtension
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.junit.jupiter.api.BeforeEach
+
+@AemStub
+class ApmtReadResourceTest : ReadResourceTest(
+    testCase {
+        paths(
+            "/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish"
+        )
+        allowedUsers(
+            ApmtUsers.AUTHOR,
+            ApmtUsers.SUPER_AUTHOR
+        )
+    }
+) {
+
+    @BeforeEach
+    fun beforeEach() {
+        AemStubExtension.registerUser("admin", "admin")
+        AemStubExtension.registerUsers(*ApmtUsers.values())
+
+        stubFor(
+            get(urlPathEqualTo("/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish.json"))
+                .withHeader(CSRF_TOKEN, matching("author|super-author"))
+                .willReturn(aResponse().withStatus(200))
+        )
+
+        stubFor(
+            get(urlPathEqualTo("/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish.json"))
+                .withHeader(CSRF_TOKEN, equalTo("user"))
+                .willReturn(aResponse().withStatus(403))
+        )
+    }
+}
+
+@AemStub
+class ApmtReadResourceWithCustomDeniedStatusTest : ReadResourceTest(
+    testCase {
+        paths(
+            "/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish"
+        )
+        allowedUsers(
+            ApmtUsers.AUTHOR,
+            ApmtUsers.SUPER_AUTHOR
+        )
+    },
+    deniedStatusCode = 404
+) {
+
+    @BeforeEach
+    fun beforeEach() {
+        AemStubExtension.registerUser("admin", "admin")
+        AemStubExtension.registerUsers(*ApmtUsers.values())
+
+        stubFor(
+            get(urlPathEqualTo("/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish.json"))
+                .withHeader(CSRF_TOKEN, matching("author|super-author"))
+                .willReturn(aResponse().withStatus(200))
+        )
+
+        stubFor(
+            get(urlPathEqualTo("/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish.json"))
+                .withHeader(CSRF_TOKEN, equalTo("user"))
+                .willReturn(aResponse().withStatus(404))
+        )
+    }
+}


### PR DESCRIPTION
Main purpose of this test is to check if user has a read access to the resource. For example if is able to see Quick Publish button.
Developer can customize `deniedStatusCode` parameter because it is a good practice to return 404 status code instead of 403 when user has no access to resource. 