### PR TITLE
Open page test maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,5 +217,10 @@ override fun toTestCaseConfiguration(): TestCaseConfiguration {
 }
 ```
 
+## Unit tests
+
+If you have some problems with specific tests you can take a look on unit tests which are located in this repository in `com.cognifide.apmt.tests` package. 
+Please mind that you are interested only in constructor part.
+
 ## License
 **APM** is licensed under [Apache License, Version 2.0 (the "License")](https://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/core/src/main/kotlin/com/cognifide/apmt/tests/page/OpenPageTest.kt
+++ b/core/src/main/kotlin/com/cognifide/apmt/tests/page/OpenPageTest.kt
@@ -2,7 +2,6 @@ package com.cognifide.apmt.tests.page
 
 import com.cognifide.apmt.TestCase
 import com.cognifide.apmt.User
-import com.cognifide.apmt.actions.page.CreatePage
 import com.cognifide.apmt.actions.page.OpenPage
 import com.cognifide.apmt.config.ConfigurationProvider
 import com.cognifide.apmt.config.Instance
@@ -18,20 +17,13 @@ import org.junit.jupiter.params.ParameterizedTest
 abstract class OpenPageTest(
     vararg testCases: TestCase,
     private val instance: Instance = ConfigurationProvider.authorInstance,
-    private val queryParams: Map<String, String> = mapOf(),
-    private val createPage: Boolean = false
+    private val queryParams: Map<String, String> = mapOf()
 ) : ApmtBaseTest(*testCases) {
 
     @DisplayName("User can open pages")
     @ParameterizedTest
     @Allowed
     fun userCanOpenPages(user: User, path: String) {
-        if (createPage && instance == ConfigurationProvider.authorInstance) {
-            val createPage = CreatePage(instance, ConfigurationProvider.apmtUser, path)
-            createPage.execute()
-            addUndoAction(createPage)
-        }
-
         OpenPage(instance, user, path, queryParams)
             .execute()
             .then()
@@ -43,12 +35,6 @@ abstract class OpenPageTest(
     @ParameterizedTest
     @Denied
     fun userCannotOpenPages(user: User, path: String) {
-        if (createPage && instance == ConfigurationProvider.authorInstance) {
-            val createPage = CreatePage(instance, ConfigurationProvider.apmtUser, path)
-            createPage.execute()
-            addUndoAction(createPage)
-        }
-
         OpenPage(instance, user, path, queryParams)
             .execute()
             .then()

--- a/core/src/main/kotlin/com/cognifide/apmt/tests/resource/ReadResourceTest.kt
+++ b/core/src/main/kotlin/com/cognifide/apmt/tests/resource/ReadResourceTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest
 abstract class ReadResourceTest(
     vararg testCases: TestCase,
     private val instance: Instance = ConfigurationProvider.authorInstance,
-    private val deniedStatusCode: Int = 403
+    private val deniedStatusCode: Int = 404
 ) : ApmtBaseTest(*testCases) {
 
     @DisplayName("User can read resources")

--- a/core/src/test/kotlin/com/cognifide/apmt/tests/page/ApmtOpenPageTest.kt
+++ b/core/src/test/kotlin/com/cognifide/apmt/tests/page/ApmtOpenPageTest.kt
@@ -1,8 +1,10 @@
 package com.cognifide.apmt.tests.page
 
+import com.cognifide.apmt.BasicTestCase
 import com.cognifide.apmt.config.ConfigurationProvider
 import com.cognifide.apmt.tests.ApmtTestCases
 import com.cognifide.apmt.tests.ApmtUsers
+import com.cognifide.apmt.tests.testCase
 import com.cognifide.apmt.util.AemStub
 import com.cognifide.apmt.util.AemStubExtension.Companion.registerUser
 import com.cognifide.apmt.util.AemStubExtension.Companion.registerUsers
@@ -42,61 +44,32 @@ class ApmtOpenPageOnPublishTest : OpenPageTest(
 
 @AemStub
 class ApmtOpenPageOnAuthorTest : OpenPageTest(
-    ApmtTestCases.OPEN_PAGE,
+    testCase {
+        paths(
+            "/content/my-site/en_gl/home.html" // Mind the `.html` in test on author
+        )
+        allowedUsers (
+            ApmtUsers.AUTHOR,
+            ApmtUsers.SUPER_AUTHOR
+        )
+    },
     instance = ConfigurationProvider.authorInstance
 ) {
-
     @BeforeEach
     fun beforeEach() {
         registerUser("admin", "admin")
         registerUsers(*ApmtUsers.values())
 
         stubFor(
-            get(urlPathEqualTo("/content/my-site/en_gl/home"))
+            get(urlPathEqualTo("/content/my-site/en_gl/home.html"))
                 .withHeader("CSRF-Token", matching("author|super-author"))
                 .willReturn(aResponse().withStatus(200))
         )
 
         stubFor(
-            get(urlPathEqualTo("/content/my-site/en_gl/home"))
+            get(urlPathEqualTo("/content/my-site/en_gl/home.html"))
                 .withHeader("CSRF-Token", equalTo("user"))
                 .willReturn(aResponse().withStatus(404))
         )
-    }
-
-    @AfterEach
-    fun verifyIfPageWasNotCreated() {
-        verify(0, postRequestedFor(urlPathEqualTo("/content/my-site/en_gl/home")))
-    }
-}
-
-@AemStub
-class ApmtOpenPageOnAuthorWithCreatePageTest : OpenPageTest(
-    ApmtTestCases.OPEN_PAGE,
-    instance = ConfigurationProvider.authorInstance,
-    createPage = true
-) {
-
-    @BeforeEach
-    fun beforeEach() {
-        registerUser("admin", "admin")
-        registerUsers(*ApmtUsers.values())
-
-        stubFor(
-            get(urlPathEqualTo("/content/my-site/en_gl/home"))
-                .withHeader("CSRF-Token", matching("author|super-author"))
-                .willReturn(aResponse().withStatus(200))
-        )
-
-        stubFor(
-            get(urlPathEqualTo("/content/my-site/en_gl/home"))
-                .withHeader("CSRF-Token", equalTo("user"))
-                .willReturn(aResponse().withStatus(404))
-        )
-    }
-
-    @AfterEach
-    fun verifyIfPageWasCreated() {
-        verify(1, postRequestedFor(urlPathEqualTo("/content/my-site/en_gl/home")))
     }
 }

--- a/core/src/test/kotlin/com/cognifide/apmt/tests/resource/ApmtReadResourceTest.kt
+++ b/core/src/test/kotlin/com/cognifide/apmt/tests/resource/ApmtReadResourceTest.kt
@@ -35,39 +35,6 @@ class ApmtReadResourceTest : ReadResourceTest(
         stubFor(
             get(urlPathEqualTo("/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish.json"))
                 .withHeader(CSRF_TOKEN, equalTo("user"))
-                .willReturn(aResponse().withStatus(403))
-        )
-    }
-}
-
-@AemStub
-class ApmtReadResourceWithCustomDeniedStatusTest : ReadResourceTest(
-    testCase {
-        paths(
-            "/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish"
-        )
-        allowedUsers(
-            ApmtUsers.AUTHOR,
-            ApmtUsers.SUPER_AUTHOR
-        )
-    },
-    deniedStatusCode = 404
-) {
-
-    @BeforeEach
-    fun beforeEach() {
-        AemStubExtension.registerUser("admin", "admin")
-        AemStubExtension.registerUsers(*ApmtUsers.values())
-
-        stubFor(
-            get(urlPathEqualTo("/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish.json"))
-                .withHeader(CSRF_TOKEN, matching("author|super-author"))
-                .willReturn(aResponse().withStatus(200))
-        )
-
-        stubFor(
-            get(urlPathEqualTo("/libs/dam/gui/content/assets/annotate/jcrcontent/actions/quickpublish.json"))
-                .withHeader(CSRF_TOKEN, equalTo("user"))
                 .willReturn(aResponse().withStatus(404))
         )
     }


### PR DESCRIPTION
We decided to remove creating page from OpenPageTest. Actually all projects have their demo content so why should we create unnecessary pages during test?